### PR TITLE
Provide better usage help for users

### DIFF
--- a/web.js
+++ b/web.js
@@ -15,7 +15,7 @@ var users = [];
 
 function setof(status, users) {
  return _.filter(users, { 'status': status }).map(function(user) {
-   return "\t" + user.username + ": " + user.comment;
+   return ">*" + user.username + "*: " + user.comment;
  }).join('\n');
 }
 
@@ -30,23 +30,22 @@ function getCurrentPairStatus(users) {
 
 
   if (yes.length > 0) {
-    status = 'Yes! Someone should come find me now. Let\'s pair:\n';
+    status = '*Yes! Someone should come find me now. Let\'s pair:*\n';
     status += yes;
   }
   if (ok.length > 0 ) {
-    status += '\n\nOk. I\'m working but feel free to interrupt me:\n';
+    status += '\n*Ok. I\'m working but feel free to interrupt me:*\n';
     status += ok;
   }
   if (no.length > 0 ) {
-    status += '\n\nNope. Do Not Disturb:\n';
+    status += '\n*Nope. Do Not Disturb:*\n';
     status += no;
   }
   if (status == '') {
-    status = 'No one up for pairing (yet!). Pair up, yo.\n';
+    status = 'No one up for pairing (yet!). Pair up, yo.\n' + help;
   } else {
-    status += '\n---------------------- Pair up, yo. (Go find \'em!) ----------------------\n';
+    status += '\n' + help + '\n---------------------- Pair up, yo. (Go find \'em!) ----------------------\n';
   }
-  status += help;
   return status;
 }
 


### PR DESCRIPTION
This should fix #3.

Some examples:

The first user to run `/pair` by itself will see:

> No one up for pairing (yet!). Pair up, yo.
> Usage:     /pair yes|ok|no <what you want to do with fun people>  (or just "/pair" to see the list)

Then, running `/pair yes` will set the user's status, display it, and display the usage help again. 

> Set your pairing status to: yes
> Yes! Someone should come find me now. Let's pair:
>    techieshark: 
> ---------------------- Pair up, yo. (Go find 'em!) ----------------------
> Usage:     /pair yes|ok|no <what you want to do with fun people>  (or just "/pair" to see the list)

Note that there is no `/pair help`. Having a `help` command only works for people who would know how to look for that, and since the usage is just one line anyway, we might as well share that. 
